### PR TITLE
adjustments for static `for`

### DIFF
--- a/lib/ecs.rhm
+++ b/lib/ecs.rhm
@@ -18,8 +18,8 @@ use_static
 
 def max_entities: 100
 
-def mutable systems: []
-def mutable components: []
+def mutable systems :~ List: []
+def mutable components :~ List: []
 
 namespace entity:
   export: Entity create available_entities lookup
@@ -119,7 +119,7 @@ class.together:
        | _entities[entity] := #true
        | _entities[entity] := #false
 
-     method entities():
+     method entities() :~ Array:
        _entities
 
   class Component(
@@ -147,7 +147,7 @@ class.together:
     method add_system(sys):
       systems := List.cons(sys, systems)
 
-    method entities():
+    method entities() :~ Sequence:
       def mutable index :: Integral = 0
       fun next():
         if index < next_index

--- a/lib/event.rhm
+++ b/lib/event.rhm
@@ -26,7 +26,7 @@ class _MessageBuffer(buffer :: gvector.GVector, mutable message_queue_index :: I
     | buffer.add(m)
     message_queue_index := message_queue_index + 1
 
-  method update(handlers):
+  method update(handlers :: Sequence):
     for:
       each:
         i : 0 .. message_queue_index

--- a/lib/gvector.rhm
+++ b/lib/gvector.rhm
@@ -14,14 +14,15 @@ annot.macro 'GVector':
       ($(statinfo_meta.map_set_key),
        gvector_set_provider),
       ($(statinfo_meta.dot_provider_key),
-       gvector_dot_provider))'
+       gvector_dot_provider),
+      ($(statinfo_meta.sequence_constructor_key),
+       in_gvector))'
   )
 fun gvector_get_provider(gvec, ind):
   gvector.#{gvector-ref}(gvec, ind)
 
 fun gvector_set_provider(gvec, ind, vl):
   gvector.#{gvector-set!}(gvec, ind, vl)
-
 
 namespace GVector:
   export: make get set insert remove remove_last add count to_vector of_vector elements sort
@@ -113,3 +114,6 @@ dot.macro
     | 'to_vector': 'fun (): GVector.to_vector($left)'
     | 'sort': 'fun (vl,$('...')): GVector.sort($left,vl,$('...'))'
     | 'elements': 'fun (): GVector.elements($left)'
+
+expr.macro 'in_gvector($expr)':
+  'gvector.#{in-gvector}($expr)'


### PR DESCRIPTION
A recent change to `rhombus-prototype` makes `for` more picky in static more. This commit adds annotations to make `for` happy again — and maybe provide a small speed bump to iteration over GVectors, but likely not in a way that matters here.